### PR TITLE
【Game検索画面の作成】data, domain層の作成

### DIFF
--- a/app/src/main/kotlin/com/lilin/gamelibrary/di/GameUseCaseModule.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/di/GameUseCaseModule.kt
@@ -3,6 +3,7 @@ package com.lilin.gamelibrary.di
 import com.lilin.gamelibrary.domain.repository.GameDetailRepository
 import com.lilin.gamelibrary.domain.repository.GameRepository
 import com.lilin.gamelibrary.domain.usecase.GetGameDetailUseCase
+import com.lilin.gamelibrary.domain.usecase.GetGameSearchUseCase
 import com.lilin.gamelibrary.domain.usecase.GetHighMetacriticScoreGamesUseCase
 import com.lilin.gamelibrary.domain.usecase.GetNewReleasesUseCase
 import com.lilin.gamelibrary.domain.usecase.GetTrendingGamesUseCase
@@ -38,5 +39,11 @@ object GameUseCaseModule {
     @ViewModelScoped
     fun provideGetGameDetailsUseCase(repository: GameDetailRepository): GetGameDetailUseCase {
         return GetGameDetailUseCase(repository)
+    }
+
+    @Provides
+    @ViewModelScoped
+    fun provideGetGameSearchUseCase(repository: GameRepository): GetGameSearchUseCase {
+        return GetGameSearchUseCase(repository)
     }
 }

--- a/app/src/main/kotlin/com/lilin/gamelibrary/domain/repository/GameRepository.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/domain/repository/GameRepository.kt
@@ -38,4 +38,18 @@ interface GameRepository {
         page: Int,
         pageSize: Int,
     ): Result<List<Game>>
+
+    /**
+     * ゲームの検索
+     *
+     * @param page ページ番号（1から始まる）
+     * @param pageSize 1ページあたりの件数
+     * @param searchText 検索キーワード
+     * @return 成功時はゲームのリスト、失敗時はエラー情報を含むResult
+     */
+    suspend fun getSearchGameResults(
+        page: Int,
+        pageSize: Int,
+        searchText: String,
+    ): Result<List<Game>>
 }

--- a/app/src/main/kotlin/com/lilin/gamelibrary/domain/repository/GameRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/domain/repository/GameRepositoryImpl.kt
@@ -39,6 +39,18 @@ class GameRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getSearchGameResults(
+        page: Int,
+        pageSize: Int,
+        searchText: String,
+    ): Result<List<Game>> {
+        val search = searchText.ifBlank { null }
+
+        return runCatching {
+            fetchGames(page, pageSize, null, null, search, "relevance,-metacritic")
+        }
+    }
+
     private suspend fun fetchGames(
         page: Int,
         pageSize: Int,

--- a/app/src/main/kotlin/com/lilin/gamelibrary/domain/usecase/GetGameSearchUseCase.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/domain/usecase/GetGameSearchUseCase.kt
@@ -1,0 +1,20 @@
+package com.lilin.gamelibrary.domain.usecase
+
+import com.lilin.gamelibrary.domain.model.Game
+import com.lilin.gamelibrary.domain.repository.GameRepository
+
+class GetGameSearchUseCase(
+    private val gameRepository: GameRepository,
+) {
+    /**
+     * ゲームの検索結果を取得する
+     *
+     * @param page ページ番号（1から始まる）
+     * @param pageSize 1ページあたりの件数
+     * @param searchText 検索キーワード
+     * @return 成功時はゲームのリスト、失敗時はエラー情報を含むResult
+     */
+    suspend operator fun invoke(page: Int, pageSize: Int, searchText: String): Result<List<Game>> {
+        return gameRepository.getSearchGameResults(page, pageSize, searchText)
+    }
+}

--- a/app/src/test/kotlin/com/lilin/gamelibrary/domain/usecase/GetGameSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/lilin/gamelibrary/domain/usecase/GetGameSearchUseCaseTest.kt
@@ -1,0 +1,75 @@
+package com.lilin.gamelibrary.domain.usecase
+
+import com.lilin.gamelibrary.domain.model.Game
+import com.lilin.gamelibrary.domain.repository.GameRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetGameSearchUseCaseTest {
+    private lateinit var gameRepository: GameRepository
+    private lateinit var useCase: GetGameSearchUseCase
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk()
+        useCase = GetGameSearchUseCase(gameRepository)
+    }
+
+    @Test
+    fun `given successful response, when getGameSearch is called, then return a list of games`() =
+        runTest {
+            val mockResponse = listOf(
+                createMockGame(1),
+                createMockGame(2),
+                createMockGame(3),
+            )
+
+            coEvery {
+                gameRepository.getSearchGameResults(1, 10, "testGame")
+            } returns Result.success(mockResponse)
+
+            val response = useCase(1, 10, "testGame")
+            assertTrue(response.isSuccess)
+            assertEquals(3, response.getOrNull()?.size)
+            assertEquals("Test Game 1", response.getOrNull()?.get(0)?.name)
+            assertEquals(1, response.getOrNull()?.get(0)?.id)
+            coVerify(exactly = 1) {
+                gameRepository.getSearchGameResults(1, 10, "testGame")
+            }
+        }
+
+    @Test
+    fun `given failure response, when getGameSearch is called, then return a failure result`() =
+        runTest {
+            val exception = kotlin.Exception("Api Error")
+            coEvery {
+                gameRepository.getSearchGameResults(1, 10, "testGame")
+            } returns Result.failure(exception)
+
+            val response = useCase(1, 10, "testGame")
+
+            assertTrue(response.isFailure)
+            assertEquals("Api Error", response.exceptionOrNull()?.message)
+        }
+
+    private fun createMockGame(id: Int): Game {
+        return Game(
+            id = id,
+            name = "Test Game $id",
+            imageUrl = "https://example.com/image$id.jpg",
+            releaseDate = "2024-01-01",
+            rating = 4.5,
+            ratingsCount = 1000,
+            metacritic = 85,
+            isTba = false,
+            addedCount = 5000,
+            platforms = listOf("PC"),
+        )
+    }
+}


### PR DESCRIPTION
## 機能
- 検索
- 部分一致含む全てListで表示
- Listの項目クリックで詳細画面へ遷移

## 対応
- ApiService修正（getGamesにsearch追加）
- data層
   - Dto（GameDtoを使用）
   - Mapper（GameMapperを使用）
- domain層
   - Repository追加
   - UseCase作成
- UnitTest
   - repository
   - usecase