### PR TITLE
Gameお気に入り画面の作成】data, domain層の作成

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,9 @@ dependencies {
     implementation(libs.hilt.navigation.compose)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.paging)
+    ksp(libs.androidx.room.compiler)
 
     // UnitTest
     testImplementation(libs.androidx.test.core)
@@ -116,6 +119,7 @@ dependencies {
     testImplementation(libs.roborazzi.compose)
     testImplementation(libs.roborazzi.junit.rule)
     testImplementation(libs.coil.test)
+    testImplementation(libs.androidx.room.testing)
     // AndroidTest
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/kotlin/com/lilin/gamelibrary/data/local/AppDatabase.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/data/local/AppDatabase.kt
@@ -1,0 +1,15 @@
+package com.lilin.gamelibrary.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.lilin.gamelibrary.data.local.dao.FavoriteGameDao
+import com.lilin.gamelibrary.data.local.entity.FavoriteGameEntity
+
+@Database(
+    entities = [FavoriteGameEntity::class],
+    version = 1,
+    exportSchema = false,
+)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun favoriteGameDao(): FavoriteGameDao
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/data/local/dao/FavoriteGameDao.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/data/local/dao/FavoriteGameDao.kt
@@ -1,0 +1,29 @@
+package com.lilin.gamelibrary.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.lilin.gamelibrary.data.local.entity.FavoriteGameEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FavoriteGameDao {
+    // 新しい順
+    @Query("SELECT * FROM favorite_games ORDER BY addedAt DESC")
+    fun getFavoriteGamesNewestFirst(): Flow<List<FavoriteGameEntity>>
+
+    // 古い順
+    @Query("SELECT * FROM favorite_games ORDER BY addedAt ASC")
+    fun getFavoriteGamesOldestFirst(): Flow<List<FavoriteGameEntity>>
+
+    // お気に入り判定用
+    @Query("SELECT EXISTS(SELECT 1 FROM favorite_games WHERE id = :gameId)")
+    fun isFavorite(gameId: Int): Flow<Boolean>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertFavoriteGame(game: FavoriteGameEntity)
+
+    @Query("DELETE FROM favorite_games WHERE id = :gameId")
+    suspend fun deleteFavoriteGame(gameId: Int)
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/data/local/entity/FavoriteGameEntity.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/data/local/entity/FavoriteGameEntity.kt
@@ -1,0 +1,16 @@
+package com.lilin.gamelibrary.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "favorite_games")
+data class FavoriteGameEntity(
+    @PrimaryKey
+    val id: Int,
+    val name: String,
+    val backgroundImage: String?,
+    val rating: Double,
+    val metacritic: Int?,
+    val released: String?,
+    val addedAt: Long,
+)

--- a/app/src/main/kotlin/com/lilin/gamelibrary/data/repository/FavoriteGameRepository.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/data/repository/FavoriteGameRepository.kt
@@ -1,0 +1,58 @@
+package com.lilin.gamelibrary.data.repository
+
+import com.lilin.gamelibrary.data.local.dao.FavoriteGameDao
+import com.lilin.gamelibrary.data.local.entity.FavoriteGameEntity
+import com.lilin.gamelibrary.domain.model.FavoriteGame
+import com.lilin.gamelibrary.domain.model.SortOrder
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class FavoriteGameRepository @Inject constructor(
+    private val favoriteGameDao: FavoriteGameDao,
+) {
+    fun getFavoriteGames(order: SortOrder): Flow<List<FavoriteGame>> {
+        return when (order) {
+            SortOrder.NEWEST_FIRST -> favoriteGameDao.getFavoriteGamesNewestFirst()
+            SortOrder.OLDEST_FIRST -> favoriteGameDao.getFavoriteGamesOldestFirst()
+        }.map { entities ->
+            entities.map { it.toDomainModel() }
+        }
+    }
+
+    fun isFavorite(gameId: Int): Flow<Boolean> {
+        return favoriteGameDao.isFavorite(gameId)
+    }
+
+    suspend fun insertFavoriteGame(game: FavoriteGame) {
+        favoriteGameDao.insertFavoriteGame(game.toEntity())
+    }
+
+    suspend fun deleteFavoriteGame(gameId: Int) {
+        favoriteGameDao.deleteFavoriteGame(gameId)
+    }
+}
+
+private fun FavoriteGameEntity.toDomainModel(): FavoriteGame {
+    return FavoriteGame(
+        id = id,
+        name = name,
+        backgroundImage = backgroundImage,
+        rating = rating,
+        metacritic = metacritic,
+        released = released,
+        addedAt = addedAt,
+    )
+}
+
+private fun FavoriteGame.toEntity(): FavoriteGameEntity {
+    return FavoriteGameEntity(
+        id = id,
+        name = name,
+        backgroundImage = backgroundImage,
+        rating = rating,
+        metacritic = metacritic,
+        released = released,
+        addedAt = addedAt,
+    )
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/di/GameUseCaseModule.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/di/GameUseCaseModule.kt
@@ -1,5 +1,6 @@
 package com.lilin.gamelibrary.di
 
+import com.lilin.gamelibrary.data.repository.FavoriteGameRepository
 import com.lilin.gamelibrary.domain.repository.GameDetailRepository
 import com.lilin.gamelibrary.domain.repository.GameRepository
 import com.lilin.gamelibrary.domain.usecase.GetGameDetailUseCase
@@ -7,6 +8,10 @@ import com.lilin.gamelibrary.domain.usecase.GetGameSearchUseCase
 import com.lilin.gamelibrary.domain.usecase.GetHighMetacriticScoreGamesUseCase
 import com.lilin.gamelibrary.domain.usecase.GetNewReleasesUseCase
 import com.lilin.gamelibrary.domain.usecase.GetTrendingGamesUseCase
+import com.lilin.gamelibrary.domain.usecase.favorite.AddFavoriteGameUseCase
+import com.lilin.gamelibrary.domain.usecase.favorite.GetFavoriteGamesUseCase
+import com.lilin.gamelibrary.domain.usecase.favorite.IsFavoriteGameUseCase
+import com.lilin.gamelibrary.domain.usecase.favorite.RemoveFavoriteGameUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -45,5 +50,29 @@ object GameUseCaseModule {
     @ViewModelScoped
     fun provideGetGameSearchUseCase(repository: GameRepository): GetGameSearchUseCase {
         return GetGameSearchUseCase(repository)
+    }
+
+    @Provides
+    @ViewModelScoped
+    fun provideGetFavoriteGamesUseCase(repository: FavoriteGameRepository): GetFavoriteGamesUseCase {
+        return GetFavoriteGamesUseCase(repository)
+    }
+
+    @Provides
+    @ViewModelScoped
+    fun provideAddFavoriteGameUseCase(repository: FavoriteGameRepository): AddFavoriteGameUseCase {
+        return AddFavoriteGameUseCase(repository)
+    }
+
+    @Provides
+    @ViewModelScoped
+    fun provideRemoveFavoriteGameUseCase(repository: FavoriteGameRepository): RemoveFavoriteGameUseCase {
+        return RemoveFavoriteGameUseCase(repository)
+    }
+
+    @Provides
+    @ViewModelScoped
+    fun provideIsFavoriteGameUseCase(repository: FavoriteGameRepository): IsFavoriteGameUseCase {
+        return IsFavoriteGameUseCase(repository)
     }
 }

--- a/app/src/main/kotlin/com/lilin/gamelibrary/di/RoomModule.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/di/RoomModule.kt
@@ -1,0 +1,36 @@
+package com.lilin.gamelibrary.di
+
+import android.content.Context
+import androidx.room.Room
+import com.lilin.gamelibrary.data.local.AppDatabase
+import com.lilin.gamelibrary.data.local.dao.FavoriteGameDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import kotlin.jvm.java
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RoomModule {
+
+    @Provides
+    @Singleton
+    fun provideAppDatabase(
+        @ApplicationContext context: Context,
+    ): AppDatabase {
+        return Room.databaseBuilder(
+            context,
+            AppDatabase::class.java,
+            "game_library_database",
+        ).build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideFavoriteGameDao(database: AppDatabase): FavoriteGameDao {
+        return database.favoriteGameDao()
+    }
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/domain/model/FavoriteGame.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/domain/model/FavoriteGame.kt
@@ -1,0 +1,11 @@
+package com.lilin.gamelibrary.domain.model
+
+data class FavoriteGame(
+    val id: Int,
+    val name: String,
+    val backgroundImage: String?,
+    val rating: Double,
+    val metacritic: Int?,
+    val released: String?,
+    val addedAt: Long,
+)

--- a/app/src/main/kotlin/com/lilin/gamelibrary/domain/model/SortOrder.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/domain/model/SortOrder.kt
@@ -1,0 +1,6 @@
+package com.lilin.gamelibrary.domain.model
+
+enum class SortOrder {
+    NEWEST_FIRST,
+    OLDEST_FIRST,
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/AddFavoriteGameUseCase.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/AddFavoriteGameUseCase.kt
@@ -1,0 +1,20 @@
+package com.lilin.gamelibrary.domain.usecase.favorite
+
+import com.lilin.gamelibrary.data.repository.FavoriteGameRepository
+import com.lilin.gamelibrary.domain.model.FavoriteGame
+import javax.inject.Inject
+
+/**
+ * ゲームをお気に入りに追加するUseCase
+ *
+ * 同じIDのゲームが既に存在する場合は上書きされる。
+ *
+ * @param game お気に入りに追加するゲーム
+ */
+class AddFavoriteGameUseCase @Inject constructor(
+    private val repository: FavoriteGameRepository,
+) {
+    suspend operator fun invoke(game: FavoriteGame) {
+        repository.insertFavoriteGame(game)
+    }
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/GetFavoriteGamesUseCase.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/GetFavoriteGamesUseCase.kt
@@ -1,0 +1,24 @@
+package com.lilin.gamelibrary.domain.usecase.favorite
+
+import com.lilin.gamelibrary.data.repository.FavoriteGameRepository
+import com.lilin.gamelibrary.domain.model.FavoriteGame
+import com.lilin.gamelibrary.domain.model.SortOrder
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/**
+ * お気に入りゲーム一覧を取得するUseCase
+ *
+ * 指定されたソート順でお気に入り登録されたゲームのリストを取得する。
+ * Flowを返すため、データベースの変更が自動的にUIに反映される。
+ *
+ * @param sortOrder ソート順（新しい順/古い順）
+ * @return お気に入りゲームのリストを流すFlow
+ */
+class GetFavoriteGamesUseCase @Inject constructor(
+    private val repository: FavoriteGameRepository,
+) {
+    operator fun invoke(sortOrder: SortOrder): Flow<List<FavoriteGame>> {
+        return repository.getFavoriteGames(sortOrder)
+    }
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/IsFavoriteGameUseCase.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/IsFavoriteGameUseCase.kt
@@ -1,0 +1,22 @@
+package com.lilin.gamelibrary.domain.usecase.favorite
+
+import com.lilin.gamelibrary.data.repository.FavoriteGameRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/**
+ * ゲームがお気に入り登録されているか確認するUseCase
+ *
+ * 指定されたIDのゲームがお気に入りに登録されているかをチェックする。
+ * Flowを返すため、お気に入り状態の変化が自動的にUIに反映される。
+ *
+ * @param gameId 確認するゲームのID
+ * @return お気に入り登録されている場合はtrue、そうでない場合はfalseを流すFlow
+ */
+class IsFavoriteGameUseCase @Inject constructor(
+    private val repository: FavoriteGameRepository,
+) {
+    operator fun invoke(gameId: Int): Flow<Boolean> {
+        return repository.isFavorite(gameId)
+    }
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/RemoveFavoriteGameUseCase.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/RemoveFavoriteGameUseCase.kt
@@ -1,0 +1,20 @@
+package com.lilin.gamelibrary.domain.usecase.favorite
+
+import com.lilin.gamelibrary.data.repository.FavoriteGameRepository
+import javax.inject.Inject
+
+/**
+ * お気に入りからゲームを削除するUseCase
+ *
+ * 指定されたIDのゲームをお気に入りから削除する。
+ * 存在しないIDが指定された場合は何も行わない。
+ *
+ * @param gameId 削除するゲームのID
+ */
+class RemoveFavoriteGameUseCase @Inject constructor(
+    private val repository: FavoriteGameRepository,
+) {
+    suspend operator fun invoke(gameId: Int) {
+        repository.deleteFavoriteGame(gameId)
+    }
+}

--- a/app/src/test/kotlin/com/lilin/gamelibrary/data/repository/FavoriteGameRepositoryTest.kt
+++ b/app/src/test/kotlin/com/lilin/gamelibrary/data/repository/FavoriteGameRepositoryTest.kt
@@ -1,0 +1,156 @@
+package com.lilin.gamelibrary.data.repository
+
+import com.lilin.gamelibrary.data.local.dao.FavoriteGameDao
+import com.lilin.gamelibrary.data.local.entity.FavoriteGameEntity
+import com.lilin.gamelibrary.domain.model.FavoriteGame
+import com.lilin.gamelibrary.domain.model.SortOrder
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+// mockの誤検知
+// https://youtrack.jetbrains.com/projects/KTIJ/issues/KTIJ-34798/K2-False-positive-inspection-Flow-is-constructed-but-not-used-with-Mockito
+@Suppress("UnusedFlow")
+class FavoriteGameRepositoryTest {
+    private lateinit var favoriteGameDao: FavoriteGameDao
+    private lateinit var favoriteGameRepository: FavoriteGameRepository
+
+    @BeforeEach
+    fun setUp() {
+        favoriteGameDao = mockk()
+        favoriteGameRepository = FavoriteGameRepository(favoriteGameDao)
+    }
+
+    @Test
+    fun `getFavoriteGames with NEWEST_FIRST returns correctly mapped games`() = runTest {
+        val entities = listOf(
+            createMockFavoriteGameEntity(1, "Game 1", 1700000000L),
+            createMockFavoriteGameEntity(2, "Game 2", 1700000001L),
+        )
+        every { favoriteGameDao.getFavoriteGamesNewestFirst() } returns flowOf(entities)
+
+        val result = favoriteGameRepository.getFavoriteGames(SortOrder.NEWEST_FIRST).toList()
+
+        assertEquals(1, result.size)
+        assertEquals(2, result[0].size)
+        assertEquals("Game 1", result[0][0].name)
+        assertEquals("Game 2", result[0][1].name)
+        verify(exactly = 1) { favoriteGameDao.getFavoriteGamesNewestFirst() }
+    }
+
+    @Test
+    fun `getFavoriteGames with OLDEST_FIRST returns correctly mapped games`() = runTest {
+        val entities = listOf(
+            createMockFavoriteGameEntity(3, "Game 3", 1700000000L),
+            createMockFavoriteGameEntity(4, "Game 4", 1700000001L),
+        )
+        every { favoriteGameDao.getFavoriteGamesOldestFirst() } returns flowOf(entities)
+
+        val result = favoriteGameRepository.getFavoriteGames(SortOrder.OLDEST_FIRST).toList()
+
+        assertEquals(1, result.size)
+        assertEquals(2, result[0].size)
+        assertEquals("Game 3", result[0][0].name)
+        assertEquals("Game 4", result[0][1].name)
+        verify(exactly = 1) { favoriteGameDao.getFavoriteGamesOldestFirst() }
+    }
+
+    @Test
+    fun `getFavoriteGames returns empty list when dao returns empty list`() = runTest {
+        every { favoriteGameDao.getFavoriteGamesNewestFirst() } returns flowOf(emptyList())
+
+        val result = favoriteGameRepository.getFavoriteGames(SortOrder.NEWEST_FIRST).toList()
+
+        assertEquals(1, result.size)
+        assertTrue(result[0].isEmpty())
+        verify(exactly = 1) { favoriteGameDao.getFavoriteGamesNewestFirst() }
+    }
+
+    @Test
+    fun `isFavorite returns true when game is favorite`() = runTest {
+        val gameId = 123
+        every { favoriteGameDao.isFavorite(gameId) } returns flowOf(true)
+
+        val result = favoriteGameRepository.isFavorite(gameId).toList()
+
+        assertEquals(1, result.size)
+        assertTrue(result[0])
+        verify(exactly = 1) { favoriteGameDao.isFavorite(gameId) }
+    }
+
+    @Test
+    fun `isFavorite returns false when game is not favorite`() = runTest {
+        val gameId = 456
+        every { favoriteGameDao.isFavorite(gameId) } returns flowOf(false)
+
+        val result = favoriteGameRepository.isFavorite(gameId).toList()
+
+        assertEquals(1, result.size)
+        assertFalse(result[0])
+        verify(exactly = 1) { favoriteGameDao.isFavorite(gameId) }
+    }
+
+    @Test
+    fun `insertFavoriteGame calls dao with correct entity`() = runTest {
+        val favoriteGame = createMockFavoriteGame()
+        coEvery { favoriteGameDao.insertFavoriteGame(any()) } returns Unit
+
+        favoriteGameRepository.insertFavoriteGame(favoriteGame)
+
+        coVerify(exactly = 1) {
+            favoriteGameDao.insertFavoriteGame(
+                match {
+                    it.id == favoriteGame.id && it.name == favoriteGame.name && it.addedAt == favoriteGame.addedAt
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `deleteFavoriteGame calls dao with correct gameId`() = runTest {
+        val gameId = 789
+        coEvery { favoriteGameDao.deleteFavoriteGame(gameId) } returns Unit
+
+        favoriteGameRepository.deleteFavoriteGame(gameId)
+
+        coVerify(exactly = 1) { favoriteGameDao.deleteFavoriteGame(gameId) }
+    }
+
+    private fun createMockFavoriteGameEntity(
+        id: Int,
+        name: String,
+        addedAt: Long,
+    ): FavoriteGameEntity {
+        return FavoriteGameEntity(
+            id = id,
+            name = name,
+            backgroundImage = "https://example.com/image$id.jpg",
+            rating = 4.5,
+            metacritic = 85,
+            released = "2024-01-01",
+            addedAt = addedAt,
+        )
+    }
+
+    private fun createMockFavoriteGame(): FavoriteGame {
+        return FavoriteGame(
+            id = 1,
+            name = "Test Game Name",
+            backgroundImage = "https://example.com/image1.jpg",
+            rating = 4.5,
+            metacritic = 85,
+            released = "2024-01-01",
+            addedAt = 1700L,
+        )
+    }
+}

--- a/app/src/test/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/AddFavoriteGameUseCaseTest.kt
+++ b/app/src/test/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/AddFavoriteGameUseCaseTest.kt
@@ -1,0 +1,60 @@
+package com.lilin.gamelibrary.domain.usecase.favorite
+
+import com.lilin.gamelibrary.data.repository.FavoriteGameRepository
+import com.lilin.gamelibrary.domain.model.FavoriteGame
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AddFavoriteGameUseCaseTest {
+
+    private lateinit var repository: FavoriteGameRepository
+    private lateinit var useCase: AddFavoriteGameUseCase
+
+    @BeforeEach
+    fun setUp() {
+        repository = mockk()
+        useCase = AddFavoriteGameUseCase(repository)
+    }
+
+    @Test
+    fun `invoke calls repository insertFavoriteGame`() = runTest {
+        val game = FavoriteGame(
+            id = 1,
+            name = "Test Game",
+            backgroundImage = "test.jpg",
+            rating = 4.5,
+            metacritic = 85,
+            released = "2023-01-01",
+            addedAt = 1000L,
+        )
+
+        coJustRun { repository.insertFavoriteGame(game) }
+
+        useCase(game)
+
+        coVerify(exactly = 1) { repository.insertFavoriteGame(game) }
+    }
+
+    @Test
+    fun `invoke with null backgroundImage calls repository insertFavoriteGame`() = runTest {
+        val game = FavoriteGame(
+            id = 2,
+            name = "Test Game 2",
+            backgroundImage = null,
+            rating = 4.0,
+            metacritic = null,
+            released = null,
+            addedAt = 2000L,
+        )
+
+        coJustRun { repository.insertFavoriteGame(game) }
+
+        useCase(game)
+
+        coVerify(exactly = 1) { repository.insertFavoriteGame(game) }
+    }
+}

--- a/app/src/test/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/GetFavoriteGamesUseCaseTest.kt
+++ b/app/src/test/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/GetFavoriteGamesUseCaseTest.kt
@@ -1,0 +1,133 @@
+package com.lilin.gamelibrary.domain.usecase.favorite
+
+import com.lilin.gamelibrary.data.repository.FavoriteGameRepository
+import com.lilin.gamelibrary.domain.model.FavoriteGame
+import com.lilin.gamelibrary.domain.model.SortOrder
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetFavoriteGamesUseCaseTest {
+    private lateinit var repository: FavoriteGameRepository
+    private lateinit var useCase: GetFavoriteGamesUseCase
+
+    @BeforeEach
+    fun setUp() {
+        repository = mockk()
+        useCase = GetFavoriteGamesUseCase(repository)
+    }
+
+    @Test
+    fun `invoke with NEWEST_FIRST returns correct flow`() = runTest {
+        val order = SortOrder.NEWEST_FIRST
+        val games = newestGames()
+
+        coEvery {
+            repository.getFavoriteGames(order)
+        } returns flowOf(games)
+
+        val result = useCase.invoke(order)
+        val actualGames = result.first()
+
+        assertEquals(games, actualGames)
+    }
+
+    @Test
+    fun `invoke with OLDEST_FIRST returns correct flow`() = runTest {
+        val order = SortOrder.OLDEST_FIRST
+        val games = oldestGames()
+
+        coEvery {
+            repository.getFavoriteGames(order)
+        } returns flowOf(games)
+
+        val result = useCase.invoke(order)
+        val actualGames = result.first()
+
+        assertEquals(games, actualGames)
+    }
+
+    @Test
+    fun `invoke with empty list returns empty flow`() = runTest {
+        val order = SortOrder.NEWEST_FIRST
+        val emptyGames = emptyList<FavoriteGame>()
+
+        coEvery {
+            repository.getFavoriteGames(order)
+        } returns flowOf(emptyGames)
+
+        val result = useCase.invoke(order)
+        val actualGames = result.first()
+
+        assertEquals(emptyGames, actualGames)
+    }
+
+    private fun newestGames(): List<FavoriteGame> {
+        return listOf(
+            FavoriteGame(
+                id = 3,
+                name = "Game 3",
+                backgroundImage = "game3.jpg",
+                rating = 4.0,
+                metacritic = 80,
+                released = "2023-03-01",
+                addedAt = 3000L,
+            ),
+            FavoriteGame(
+                id = 2,
+                name = "Game 2",
+                backgroundImage = "game2.jpg",
+                rating = 4.0,
+                metacritic = 80,
+                released = "2023-02-01",
+                addedAt = 2000L,
+            ),
+            FavoriteGame(
+                id = 1,
+                name = "Game 1",
+                backgroundImage = "game1.jpg",
+                rating = 4.0,
+                metacritic = 80,
+                released = "2023-01-01",
+                addedAt = 1000L,
+            ),
+        )
+    }
+
+    private fun oldestGames(): List<FavoriteGame> {
+        return listOf(
+            FavoriteGame(
+                id = 1,
+                name = "Game 1",
+                backgroundImage = "game1.jpg",
+                rating = 4.0,
+                metacritic = 80,
+                released = "2023-01-01",
+                addedAt = 1000L,
+            ),
+            FavoriteGame(
+                id = 2,
+                name = "Game 2",
+                backgroundImage = "game2.jpg",
+                rating = 4.0,
+                metacritic = 80,
+                released = "2023-02-01",
+                addedAt = 2000L,
+            ),
+            FavoriteGame(
+                id = 3,
+                name = "Game 3",
+                backgroundImage = "game3.jpg",
+                rating = 4.0,
+                metacritic = 80,
+                released = "2023-03-01",
+                addedAt = 3000L,
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/IsFavoriteGameUseCaseTest.kt
+++ b/app/src/test/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/IsFavoriteGameUseCaseTest.kt
@@ -1,0 +1,50 @@
+package com.lilin.gamelibrary.domain.usecase.favorite
+
+import com.lilin.gamelibrary.data.repository.FavoriteGameRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class IsFavoriteGameUseCaseTest {
+    private lateinit var repository: FavoriteGameRepository
+    private lateinit var useCase: IsFavoriteGameUseCase
+
+    @BeforeEach
+    fun setUp() {
+        repository = mockk()
+        useCase = IsFavoriteGameUseCase(repository)
+    }
+
+    @Test
+    fun `invoke with favorite game returns true`() = runTest {
+        val gameId = 1
+
+        coEvery {
+            repository.isFavorite(gameId)
+        } returns flowOf(true)
+
+        val result = useCase.invoke(gameId)
+        val isFavorite = result.first()
+
+        assertEquals(true, isFavorite)
+    }
+
+    @Test
+    fun `invoke with non-favorite game returns false`() = runTest {
+        val gameId = 2
+
+        coEvery {
+            repository.isFavorite(gameId)
+        } returns flowOf(false)
+
+        val result = useCase.invoke(gameId)
+        val isFavorite = result.first()
+
+        assertEquals(false, isFavorite)
+    }
+}

--- a/app/src/test/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/RemoveFavoriteGameUseCaseTest.kt
+++ b/app/src/test/kotlin/com/lilin/gamelibrary/domain/usecase/favorite/RemoveFavoriteGameUseCaseTest.kt
@@ -1,0 +1,31 @@
+package com.lilin.gamelibrary.domain.usecase.favorite
+
+import com.lilin.gamelibrary.data.repository.FavoriteGameRepository
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class RemoveFavoriteGameUseCaseTest {
+    private lateinit var repository: FavoriteGameRepository
+    private lateinit var useCase: RemoveFavoriteGameUseCase
+
+    @BeforeEach
+    fun setUp() {
+        repository = mockk()
+        useCase = RemoveFavoriteGameUseCase(repository)
+    }
+
+    @Test
+    fun `invoke calls repository deleteFavoriteGame`() = runTest {
+        val gameId = 1
+
+        coJustRun { repository.deleteFavoriteGame(gameId) }
+
+        useCase(gameId)
+
+        coVerify(exactly = 1) { repository.deleteFavoriteGame(gameId) }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ retrofit = "3.0.0"
 okhttp3 = "4.12.0"
 retrofit-converter = "1.0.0"
 coil = "3.3.0"
+room = "2.8.4"
 # DI
 hilt = "2.57.2"
 hiltNavigation = "1.3.0"
@@ -50,6 +51,10 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-room-paging = { group = "androidx.room", name = "room-paging", version.ref = "room" }
+
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinSerialization" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinDatetime" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
@@ -78,6 +83,7 @@ junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5VintageEngine" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinCoroutinesTest" }
 coil-test = { group = "io.coil-kt.coil3", name = "coil-test", version.ref = "coil" }
+androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 
 # Lint
 detekt-compose = { group = "io.nlopez.compose.rules", name = "detekt", version.ref = "detektCompose" }


### PR DESCRIPTION
## 機能
- 全てListで表示
- Listの項目クリックで詳細画面へ遷移
-  お気に入りのゲームで削除ボタンでdatabaseから削除

## 対応
- data層
   - Entityの作成
   - Daoの作成
   - Databaseの作成
   - Repositoryの作成
- domain層
   - UseCase作成
- UnitTest
   - repository
   - usecase