### PR TITLE
【デザイン改善】Loading、Error時の表示を追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,7 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.paging)
     ksp(libs.androidx.room.compiler)
+    implementation(libs.compose.shimmer)
 
     // UnitTest
     testImplementation(libs.androidx.test.core)

--- a/app/src/main/kotlin/com/lilin/gamelibrary/feature/discovery/DiscoveryScreen.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/feature/discovery/DiscoveryScreen.kt
@@ -1,25 +1,47 @@
 package com.lilin.gamelibrary.feature.discovery
 
 import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.lilin.gamelibrary.R
 import com.lilin.gamelibrary.domain.model.Game
 import com.lilin.gamelibrary.navigation.TOP_LEVEL_ROUTES
 import com.lilin.gamelibrary.ui.component.DiscoveryTopBar
@@ -27,6 +49,7 @@ import com.lilin.gamelibrary.ui.component.GameLibraryNavigationBar
 import com.lilin.gamelibrary.ui.component.discovery.HighRatedGamesSection
 import com.lilin.gamelibrary.ui.component.discovery.NewReleaseGamesSection
 import com.lilin.gamelibrary.ui.component.discovery.TrendingGamesSection
+import kotlinx.coroutines.flow.combine
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -55,6 +78,18 @@ fun DiscoveryScreen(
     val highlyRatedState by viewModel.highlyRatedState.collectAsState()
     val newReleasesState by viewModel.newReleasesState.collectAsState()
 
+    val isInitialLoading by remember {
+        combine(
+            viewModel.trendingState,
+            viewModel.highlyRatedState,
+            viewModel.newReleasesState,
+        ) { trending, highlyRated, newReleases ->
+            trending is DiscoveryUiState.InitialLoading ||
+                    highlyRated is DiscoveryUiState.InitialLoading ||
+                    newReleases is DiscoveryUiState.InitialLoading
+        }
+    }.collectAsState(initial = true)
+
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
@@ -68,8 +103,10 @@ fun DiscoveryScreen(
             trendingState = trendingState,
             highlyRatedState = highlyRatedState,
             newReleasesState = newReleasesState,
+            isInitialLoading = isInitialLoading,
             scrollBehavior = scrollBehavior,
             onNavigateToDetail = onNavigateToDetail,
+            loadingAllSection = viewModel::loadAllSections,
             modifier = Modifier.padding(paddingValues),
         )
     }
@@ -81,37 +118,133 @@ private fun DiscoveryScreen(
     trendingState: DiscoveryUiState,
     highlyRatedState: DiscoveryUiState,
     newReleasesState: DiscoveryUiState,
+    isInitialLoading: Boolean,
     scrollBehavior: TopAppBarScrollBehavior,
     onNavigateToDetail: (Int) -> Unit,
+    loadingAllSection: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
+    val isAllError = trendingState is DiscoveryUiState.Error &&
+            highlyRatedState is DiscoveryUiState.Error &&
+            newReleasesState is DiscoveryUiState.Error
+
+    when {
+        isInitialLoading -> {
+            InitialLoadingScreen(
+                modifier = modifier,
+            )
+        }
+
+        isAllError -> {
+            FullScreenError(
+                onRetry = loadingAllSection,
+                modifier = modifier,
+            )
+        }
+
+        else -> {
+            LazyColumn(
+                modifier = modifier
+                    .nestedScroll(scrollBehavior.nestedScrollConnection),
+                contentPadding = PaddingValues(bottom = 12.dp),
+            ) {
+                item {
+                    TrendingGames(
+                        uiState = trendingState,
+                        onNavigateToDetail = onNavigateToDetail,
+                        modifier = Modifier,
+                    )
+                }
+
+                item {
+                    HighRatedGames(
+                        uiState = highlyRatedState,
+                        onNavigateToDetail = onNavigateToDetail,
+                        modifier = Modifier,
+                    )
+                }
+
+                item {
+                    NewReleaseGames(
+                        uiState = newReleasesState,
+                        onNavigateToDetail = onNavigateToDetail,
+                        modifier = Modifier,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InitialLoadingScreen(
+    modifier: Modifier = Modifier,
+) {
+    Box(
         modifier = modifier
-            .nestedScroll(scrollBehavior.nestedScrollConnection),
-        contentPadding = PaddingValues(bottom = 12.dp),
+            .fillMaxSize(),
+        contentAlignment = Alignment.Center,
     ) {
-        item {
-            TrendingGames(
-                uiState = trendingState,
-                onNavigateToDetail = onNavigateToDetail,
-                modifier = Modifier,
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            CircularProgressIndicator()
+            Text(
+                text = stringResource(R.string.discovery_loading_message),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
             )
         }
+    }
+}
 
-        item {
-            HighRatedGames(
-                uiState = highlyRatedState,
-                onNavigateToDetail = onNavigateToDetail,
-                modifier = Modifier,
+@Composable
+private fun FullScreenError(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(32.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.ErrorOutline,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.error,
             )
-        }
 
-        item {
-            NewReleaseGames(
-                uiState = newReleasesState,
-                onNavigateToDetail = onNavigateToDetail,
-                modifier = Modifier,
+            Text(
+                text = stringResource(R.string.discovery_error_message),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
             )
+
+            Text(
+                text = stringResource(R.string.discovery_error_submessage),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Button(onClick = onRetry) {
+                Icon(
+                    imageVector = Icons.Rounded.Refresh,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(R.string.discovery_retry_button_text))
+            }
         }
     }
 }
@@ -137,6 +270,7 @@ private fun TrendingGames(
         is DiscoveryUiState.Error -> {}
         is DiscoveryUiState.ReLoading -> {}
         is DiscoveryUiState.ReLoadingError -> {}
+        is DiscoveryUiState.InitialLoading -> {}
     }
 }
 
@@ -161,6 +295,7 @@ private fun HighRatedGames(
         is DiscoveryUiState.Error -> {}
         is DiscoveryUiState.ReLoading -> {}
         is DiscoveryUiState.ReLoadingError -> {}
+        is DiscoveryUiState.InitialLoading -> {}
     }
 }
 
@@ -185,6 +320,7 @@ private fun NewReleaseGames(
         is DiscoveryUiState.Error -> {}
         is DiscoveryUiState.ReLoading -> {}
         is DiscoveryUiState.ReLoadingError -> {}
+        is DiscoveryUiState.InitialLoading -> {}
     }
 }
 
@@ -201,8 +337,10 @@ internal fun DiscoveryScreenSample(
         trendingState = trendingState,
         highlyRatedState = highlyRatedState,
         newReleasesState = newReleasesState,
+        isInitialLoading = false,
         scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
         onNavigateToDetail = {},
+        loadingAllSection = {},
         modifier = modifier,
     )
 }

--- a/app/src/main/kotlin/com/lilin/gamelibrary/feature/discovery/DiscoveryScreen.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/feature/discovery/DiscoveryScreen.kt
@@ -117,6 +117,9 @@ fun DiscoveryScreen(
             scrollBehavior = scrollBehavior,
             onNavigateToDetail = onNavigateToDetail,
             loadingAllSection = viewModel::loadAllSections,
+            onReloadTrendSection = viewModel::reloadTrendingGames,
+            onReloadHighRatedSection = viewModel::reloadHighlyRatedGames,
+            onReloadNewReleaseSection = viewModel::reloadNewReleaseGame,
             onRetryTrendSection = viewModel::retryTrendingGames,
             onRetryHighRatedSection = viewModel::retryHighlyRatedGames,
             onRetryNewReleaseSection = viewModel::retryNewReleases,
@@ -135,6 +138,9 @@ private fun DiscoveryScreen(
     scrollBehavior: TopAppBarScrollBehavior,
     onNavigateToDetail: (Int) -> Unit,
     loadingAllSection: () -> Unit,
+    onReloadTrendSection: () -> Unit,
+    onReloadHighRatedSection: () -> Unit,
+    onReloadNewReleaseSection: () -> Unit,
     onRetryTrendSection: () -> Unit,
     onRetryHighRatedSection: () -> Unit,
     onRetryNewReleaseSection: () -> Unit,
@@ -170,6 +176,7 @@ private fun DiscoveryScreen(
                         uiState = trendingState,
                         onNavigateToDetail = onNavigateToDetail,
                         onRetry = onRetryTrendSection,
+                        onReload = onReloadTrendSection,
                         modifier = Modifier,
                     )
                 }
@@ -178,8 +185,9 @@ private fun DiscoveryScreen(
                     HighRatedGames(
                         uiState = highlyRatedState,
                         onNavigateToDetail = onNavigateToDetail,
-                        modifier = Modifier,
                         onRetry = onRetryHighRatedSection,
+                        onReload = onReloadHighRatedSection,
+                        modifier = Modifier,
                     )
                 }
 
@@ -187,8 +195,9 @@ private fun DiscoveryScreen(
                     NewReleaseGames(
                         uiState = newReleasesState,
                         onNavigateToDetail = onNavigateToDetail,
-                        modifier = Modifier,
                         onRetry = onRetryNewReleaseSection,
+                        onReload = onReloadNewReleaseSection,
+                        modifier = Modifier,
                     )
                 }
             }
@@ -273,16 +282,19 @@ private fun FullScreenError(
 private fun TrendingGames(
     uiState: DiscoveryUiState,
     onNavigateToDetail: (Int) -> Unit,
+    onReload: () -> Unit,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     when (uiState) {
         is DiscoveryUiState.Success -> {
             TrendingGamesSection(
+                isSuccessState = true,
                 games = uiState.data,
                 onGameClick = { game ->
                     onNavigateToDetail(game.id)
                 },
+                onReload = onReload,
                 modifier = modifier,
             )
         }
@@ -314,7 +326,16 @@ private fun TrendingGames(
             )
         }
 
-        is DiscoveryUiState.ReLoadingError -> {}
+        is DiscoveryUiState.ReLoadingError -> {
+            ErrorSection(
+                sectionType = SectionType.TRENDING,
+                sectionColor = TrendingGradientStart,
+                sectionIcon = Icons.Filled.Whatshot,
+                throwable = uiState.throwable,
+                onRetry = onRetry,
+                modifier = modifier,
+            )
+        }
         is DiscoveryUiState.InitialLoading -> {
             // no-op
         }
@@ -325,16 +346,19 @@ private fun TrendingGames(
 private fun HighRatedGames(
     uiState: DiscoveryUiState,
     onNavigateToDetail: (Int) -> Unit,
+    onReload: () -> Unit,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     when (uiState) {
         is DiscoveryUiState.Success -> {
             HighRatedGamesSection(
+                isSuccessState = true,
                 games = uiState.data,
                 onGameClick = { game ->
                     onNavigateToDetail(game.id)
                 },
+                onReload = onReload,
                 modifier = modifier,
             )
         }
@@ -366,7 +390,16 @@ private fun HighRatedGames(
             )
         }
 
-        is DiscoveryUiState.ReLoadingError -> {}
+        is DiscoveryUiState.ReLoadingError -> {
+            ErrorSection(
+                sectionType = SectionType.HIGH_RATED,
+                sectionColor = HighRatedGradientStart,
+                sectionIcon = Icons.Filled.Star,
+                throwable = uiState.throwable,
+                onRetry = onRetry,
+                modifier = modifier,
+            )
+        }
         is DiscoveryUiState.InitialLoading -> {
             // no-op
         }
@@ -377,16 +410,19 @@ private fun HighRatedGames(
 private fun NewReleaseGames(
     uiState: DiscoveryUiState,
     onNavigateToDetail: (Int) -> Unit,
+    onReload: () -> Unit,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     when (uiState) {
         is DiscoveryUiState.Success -> {
             NewReleaseGamesSection(
+                isSuccessState = true,
                 games = uiState.data,
                 onGameClick = { game ->
                     onNavigateToDetail(game.id)
                 },
+                onReload = onReload,
                 modifier = modifier,
             )
         }
@@ -409,16 +445,25 @@ private fun NewReleaseGames(
 
         is DiscoveryUiState.Error -> {
             ErrorSection(
-                sectionType = SectionType.HIGH_RATED,
+                sectionType = SectionType.NEW_RELEASE,
                 sectionColor = NewReleaseGradientStart,
-                Icons.Filled.NewReleases,
+                sectionIcon = Icons.Filled.NewReleases,
                 throwable = uiState.throwable,
                 onRetry = onRetry,
                 modifier = modifier,
             )
         }
 
-        is DiscoveryUiState.ReLoadingError -> {}
+        is DiscoveryUiState.ReLoadingError -> {
+            ErrorSection(
+                sectionType = SectionType.NEW_RELEASE,
+                sectionColor = NewReleaseGradientStart,
+                sectionIcon = Icons.Filled.NewReleases,
+                throwable = uiState.throwable,
+                onRetry = onRetry,
+                modifier = modifier,
+            )
+        }
         is DiscoveryUiState.InitialLoading -> {
             // no-op
         }
@@ -442,6 +487,9 @@ internal fun DiscoveryScreenSample(
         scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
         onNavigateToDetail = {},
         loadingAllSection = {},
+        onReloadTrendSection = {},
+        onReloadHighRatedSection = {},
+        onReloadNewReleaseSection = {},
         onRetryTrendSection = {},
         onRetryHighRatedSection = {},
         onRetryNewReleaseSection = {},

--- a/app/src/main/kotlin/com/lilin/gamelibrary/feature/discovery/DiscoveryScreen.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/feature/discovery/DiscoveryScreen.kt
@@ -51,8 +51,10 @@ import com.lilin.gamelibrary.ui.component.DiscoveryTopBar
 import com.lilin.gamelibrary.ui.component.GameLibraryNavigationBar
 import com.lilin.gamelibrary.ui.component.discovery.ErrorSection
 import com.lilin.gamelibrary.ui.component.discovery.HighRatedGamesSection
+import com.lilin.gamelibrary.ui.component.discovery.LoadingGamesSection
 import com.lilin.gamelibrary.ui.component.discovery.NewReleaseGamesSection
 import com.lilin.gamelibrary.ui.component.discovery.SectionType
+import com.lilin.gamelibrary.ui.component.discovery.TrendingGameCardLoading
 import com.lilin.gamelibrary.ui.component.discovery.TrendingGamesSection
 import com.lilin.gamelibrary.ui.theme.HighRatedGradientStart
 import com.lilin.gamelibrary.ui.theme.NewReleaseGradientStart
@@ -285,7 +287,22 @@ private fun TrendingGames(
             )
         }
 
-        is DiscoveryUiState.Loading -> {}
+        is DiscoveryUiState.Loading -> {
+            LoadingGamesSection(
+                sectionType = SectionType.TRENDING,
+                modifier = modifier,
+                content = { TrendingGameCardLoading() },
+            )
+        }
+
+        is DiscoveryUiState.ReLoading -> {
+            LoadingGamesSection(
+                sectionType = SectionType.TRENDING,
+                modifier = modifier,
+                content = { TrendingGameCardLoading() },
+            )
+        }
+
         is DiscoveryUiState.Error -> {
             ErrorSection(
                 sectionType = SectionType.TRENDING,
@@ -297,9 +314,10 @@ private fun TrendingGames(
             )
         }
 
-        is DiscoveryUiState.ReLoading -> {}
         is DiscoveryUiState.ReLoadingError -> {}
-        is DiscoveryUiState.InitialLoading -> {}
+        is DiscoveryUiState.InitialLoading -> {
+            // no-op
+        }
     }
 }
 
@@ -321,7 +339,22 @@ private fun HighRatedGames(
             )
         }
 
-        is DiscoveryUiState.Loading -> {}
+        is DiscoveryUiState.Loading -> {
+            LoadingGamesSection(
+                sectionType = SectionType.HIGH_RATED,
+                modifier = modifier,
+                content = { TrendingGameCardLoading() },
+            )
+        }
+
+        is DiscoveryUiState.ReLoading -> {
+            LoadingGamesSection(
+                sectionType = SectionType.HIGH_RATED,
+                modifier = modifier,
+                content = { TrendingGameCardLoading() },
+            )
+        }
+
         is DiscoveryUiState.Error -> {
             ErrorSection(
                 sectionType = SectionType.HIGH_RATED,
@@ -333,9 +366,10 @@ private fun HighRatedGames(
             )
         }
 
-        is DiscoveryUiState.ReLoading -> {}
         is DiscoveryUiState.ReLoadingError -> {}
-        is DiscoveryUiState.InitialLoading -> {}
+        is DiscoveryUiState.InitialLoading -> {
+            // no-op
+        }
     }
 }
 
@@ -357,7 +391,22 @@ private fun NewReleaseGames(
             )
         }
 
-        is DiscoveryUiState.Loading -> {}
+        is DiscoveryUiState.Loading -> {
+            LoadingGamesSection(
+                sectionType = SectionType.NEW_RELEASE,
+                modifier = modifier,
+                content = { TrendingGameCardLoading() },
+            )
+        }
+
+        is DiscoveryUiState.ReLoading -> {
+            LoadingGamesSection(
+                sectionType = SectionType.NEW_RELEASE,
+                modifier = modifier,
+                content = { TrendingGameCardLoading() },
+            )
+        }
+
         is DiscoveryUiState.Error -> {
             ErrorSection(
                 sectionType = SectionType.HIGH_RATED,
@@ -369,9 +418,10 @@ private fun NewReleaseGames(
             )
         }
 
-        is DiscoveryUiState.ReLoading -> {}
         is DiscoveryUiState.ReLoadingError -> {}
-        is DiscoveryUiState.InitialLoading -> {}
+        is DiscoveryUiState.InitialLoading -> {
+            // no-op
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/lilin/gamelibrary/feature/discovery/DiscoveryUiState.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/feature/discovery/DiscoveryUiState.kt
@@ -3,6 +3,7 @@ package com.lilin.gamelibrary.feature.discovery
 import com.lilin.gamelibrary.domain.model.Game
 
 sealed interface DiscoveryUiState {
+    data object InitialLoading : DiscoveryUiState
     data object Loading : DiscoveryUiState
 
     data class Success(

--- a/app/src/main/kotlin/com/lilin/gamelibrary/feature/discovery/DiscoveryViewModel.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/feature/discovery/DiscoveryViewModel.kt
@@ -18,13 +18,13 @@ class DiscoveryViewModel @Inject constructor(
     private val getHighRatedGamesUseCase: GetHighMetacriticScoreGamesUseCase,
     private val getNewReleasesUseCase: GetNewReleasesUseCase,
 ) : ViewModel() {
-    private val _trendingState = MutableStateFlow<DiscoveryUiState>(DiscoveryUiState.Loading)
+    private val _trendingState = MutableStateFlow<DiscoveryUiState>(DiscoveryUiState.InitialLoading)
     val trendingState = _trendingState.asStateFlow()
 
-    private val _highlyRatedState = MutableStateFlow<DiscoveryUiState>(DiscoveryUiState.Loading)
+    private val _highlyRatedState = MutableStateFlow<DiscoveryUiState>(DiscoveryUiState.InitialLoading)
     val highlyRatedState = _highlyRatedState.asStateFlow()
 
-    private val _newReleasesState = MutableStateFlow<DiscoveryUiState>(DiscoveryUiState.Loading)
+    private val _newReleasesState = MutableStateFlow<DiscoveryUiState>(DiscoveryUiState.InitialLoading)
     val newReleasesState = _newReleasesState.asStateFlow()
 
     init {
@@ -73,7 +73,11 @@ class DiscoveryViewModel @Inject constructor(
         }
     }
 
-    private fun loadAllSections() {
+    fun loadAllSections() {
+        _trendingState.value = DiscoveryUiState.InitialLoading
+        _highlyRatedState.value = DiscoveryUiState.InitialLoading
+        _newReleasesState.value = DiscoveryUiState.InitialLoading
+
         loadTrendingGames()
         loadHighlyRatedGames()
         loadNewReleaseGames()

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/ErrorCard.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/ErrorCard.kt
@@ -69,7 +69,7 @@ fun ErrorCard(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .defaultMinSize(minHeight = 180.dp)
+                    .defaultMinSize(minHeight = 220.dp)
                     .padding(20.dp),
             ) {
                 Icon(

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/ErrorCard.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/ErrorCard.kt
@@ -1,0 +1,152 @@
+package com.lilin.gamelibrary.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Whatshot
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lilin.gamelibrary.R
+
+@Composable
+fun ErrorCard(
+    error: ErrorMessage,
+    sectionColor: Color,
+    sectionIcon: ImageVector,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(4.dp),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(4.dp)
+                    .background(
+                        Brush.horizontalGradient(
+                            colors = listOf(
+                                sectionColor.copy(alpha = 0.3f),
+                                sectionColor,
+                                sectionColor.copy(alpha = 0.3f),
+                            ),
+                        ),
+                    ),
+            )
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .defaultMinSize(minHeight = 180.dp)
+                    .padding(20.dp),
+            ) {
+                Icon(
+                    imageVector = sectionIcon,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .align(Alignment.TopStart),
+                    tint = sectionColor,
+                )
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.Center),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = error.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    // サブタイトル（中央寄せ）
+                    Text(
+                        text = error.subtitle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // リトライボタン（中央）
+                    Button(
+                        onClick = onRetry,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = sectionColor,
+                        ),
+                        shape = RoundedCornerShape(20.dp),
+                        modifier = Modifier.height(40.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Refresh,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(R.string.discovery_retry_section_button_text),
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ErrorCardPreview() {
+    ErrorCard(
+        error = ErrorMessage(
+            title = "Error Title",
+            subtitle = "Error Message",
+        ),
+        sectionColor = Color(0xFFFF6B6B),
+        sectionIcon = Icons.Filled.Whatshot,
+        onRetry = {},
+    )
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/ErrorMessage.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/ErrorMessage.kt
@@ -1,0 +1,27 @@
+package com.lilin.gamelibrary.ui.component
+
+import java.io.IOException
+
+data class ErrorMessage(
+    val title: String,
+    val subtitle: String,
+)
+
+fun Throwable.toErrorMessage(): ErrorMessage {
+    return when {
+        this is IOException -> ErrorMessage(
+            title = "ネットワークエラー",
+            subtitle = "インターネット接続を確認してください",
+        )
+
+        message?.contains("timeout", ignoreCase = true) == true -> ErrorMessage(
+            title = "接続がタイムアウトしました",
+            subtitle = "もう一度試すか、しばらく待ってください",
+        )
+
+        else -> ErrorMessage(
+            title = "データの取得に失敗しました",
+            subtitle = "しばらくしてからもう一度お試しください",
+        )
+    }
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameCard.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameCard.kt
@@ -14,11 +14,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
 import androidx.compose.material.icons.rounded.CalendarMonth
 import androidx.compose.material.icons.rounded.Games
 import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,6 +33,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -484,6 +487,55 @@ private fun NewReleaseGameInfoOverlay(
     }
 }
 
+@Composable
+fun SeeMoreCard(
+    sectionType: SectionType,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.size(200.dp, 220.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp),
+                    tint = sectionType.gradientStart,
+                )
+
+                Text(
+                    text = stringResource(R.string.discover_game_card_see_more),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                Text(
+                    text = stringResource(sectionType.titleId),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
 /**
  * Metacriticスコアに応じた色を取得。
  */
@@ -571,3 +623,13 @@ private fun NewReleaseGameCardPreview() {
         onClick = {},
     )
 }
+
+@Preview
+@Composable
+private fun SeeMoreCardPreview() {
+    SeeMoreCard(
+        sectionType = SectionType.TRENDING,
+        onClick = {},
+    )
+}
+

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameCard.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameCard.kt
@@ -632,4 +632,3 @@ private fun SeeMoreCardPreview() {
         onClick = {},
     )
 }
-

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameCardLoading.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameCardLoading.kt
@@ -1,0 +1,285 @@
+package com.lilin.gamelibrary.ui.component.discovery
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.valentinilk.shimmer.ShimmerBounds
+import com.valentinilk.shimmer.rememberShimmer
+import com.valentinilk.shimmer.shimmer
+
+@Composable
+fun TrendingGameCardLoading(
+    modifier: Modifier = Modifier,
+) {
+    val shimmer = rememberShimmer(shimmerBounds = ShimmerBounds.Window)
+
+    Card(
+        modifier = modifier.size(200.dp, 220.dp),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(0.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .shimmer(shimmer),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+            )
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(12.dp)
+                    .size(60.dp, 28.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        shape = RoundedCornerShape(6.dp),
+                    ),
+            )
+
+            // テキスト情報エリア
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(horizontal = 12.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                // タイトル（2行）
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(24.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            shape = RoundedCornerShape(4.dp),
+                        ),
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.7f)
+                        .height(24.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            shape = RoundedCornerShape(4.dp),
+                        ),
+                )
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(60.dp, 16.dp)
+                            .background(
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                shape = RoundedCornerShape(4.dp),
+                            ),
+                    )
+                    Box(
+                        modifier = Modifier
+                            .size(50.dp, 16.dp)
+                            .background(
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                shape = RoundedCornerShape(4.dp),
+                            ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun HighRatedGameCardLoading(
+    modifier: Modifier = Modifier,
+) {
+    val shimmer = rememberShimmer(shimmerBounds = ShimmerBounds.Window)
+
+    Card(
+        modifier = modifier.size(200.dp, 220.dp),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(0.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .shimmer(shimmer),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+            )
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(12.dp)
+                    .size(72.dp, 28.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        shape = RoundedCornerShape(6.dp),
+                    ),
+            )
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(12.dp)
+                    .size(56.dp, 56.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        shape = RoundedCornerShape(12.dp),
+                    ),
+            )
+
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(horizontal = 12.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(24.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            shape = RoundedCornerShape(4.dp),
+                        ),
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.7f)
+                        .height(24.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            shape = RoundedCornerShape(4.dp),
+                        ),
+                )
+
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(100.dp, 16.dp)
+                            .background(
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                shape = RoundedCornerShape(4.dp),
+                            ),
+                    )
+                    Box(
+                        modifier = Modifier
+                            .size(120.dp, 16.dp)
+                            .background(
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                shape = RoundedCornerShape(4.dp),
+                            ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun NewReleaseGameCardLoading(
+    modifier: Modifier = Modifier,
+) {
+    val shimmer = rememberShimmer(shimmerBounds = ShimmerBounds.Window)
+
+    Card(
+        modifier = modifier.size(200.dp, 220.dp),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(0.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .shimmer(shimmer),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+            )
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(12.dp)
+                    .size(52.dp, 28.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        shape = RoundedCornerShape(6.dp),
+                    ),
+            )
+
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(horizontal = 12.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(24.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            shape = RoundedCornerShape(4.dp),
+                        ),
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.7f)
+                        .height(24.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            shape = RoundedCornerShape(4.dp),
+                        ),
+                )
+
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(100.dp, 16.dp)
+                            .background(
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                shape = RoundedCornerShape(4.dp),
+                            ),
+                    )
+                    Box(
+                        modifier = Modifier
+                            .size(120.dp, 16.dp)
+                            .background(
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                shape = RoundedCornerShape(4.dp),
+                            ),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSectionHeader.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSectionHeader.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.LocalFireDepartment
 import androidx.compose.material.icons.rounded.NewReleases
+import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Stars
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,7 +40,9 @@ import com.lilin.gamelibrary.ui.theme.TrendingGradientStart
 
 @Composable
 fun GameSectionHeader(
+    isSuccessState: Boolean,
     sectionType: SectionType,
+    onReload: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -83,6 +87,16 @@ fun GameSectionHeader(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+
+        if (isSuccessState) {
+            IconButton(onClick = onReload) {
+                Icon(
+                    imageVector = Icons.Rounded.Refresh,
+                    contentDescription = "Reload",
+                    tint = sectionType.gradientEnd,
+                )
+            }
+        }
     }
 }
 
@@ -123,7 +137,9 @@ enum class SectionType(
 @Composable
 private fun GameSectionHeaderTrendingPreview() {
     GameSectionHeader(
+        isSuccessState = true,
         sectionType = SectionType.TRENDING,
+        onReload = {},
     )
 }
 
@@ -134,7 +150,9 @@ private fun GameSectionHeaderTrendingPreview() {
 @Composable
 private fun GameSectionHeaderHighRatedPreview() {
     GameSectionHeader(
+        isSuccessState = true,
         sectionType = SectionType.HIGH_RATED,
+        onReload = {},
     )
 }
 
@@ -145,6 +163,8 @@ private fun GameSectionHeaderHighRatedPreview() {
 @Composable
 private fun GameSectionHeaderNewReleasePreview() {
     GameSectionHeader(
+        isSuccessState = true,
         sectionType = SectionType.NEW_RELEASE,
+        onReload = {},
     )
 }

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSections.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSections.kt
@@ -151,7 +151,9 @@ fun LoadingGamesSection(
         GameSectionHeader(
             isSuccessState = false,
             sectionType = sectionType,
-            onReload = { /** no-op **/ },
+            onReload = {
+                // no-op
+            },
             modifier = Modifier,
         )
 
@@ -179,7 +181,9 @@ fun ErrorSection(
         GameSectionHeader(
             isSuccessState = false,
             sectionType = sectionType,
-            onReload = { /** no-op **/ },
+            onReload = {
+                // no-op
+            },
             modifier = Modifier,
         )
 

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSections.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSections.kt
@@ -3,13 +3,18 @@ package com.lilin.gamelibrary.ui.component.discovery
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lilin.gamelibrary.domain.model.Game
+import com.lilin.gamelibrary.ui.component.ErrorCard
+import com.lilin.gamelibrary.ui.component.toErrorMessage
 
 @Composable
 fun TrendingGamesSection(
@@ -92,6 +97,31 @@ fun NewReleaseGamesSection(
                 )
             }
         }
+    }
+}
+
+@Composable
+fun ErrorSection(
+    sectionType: SectionType,
+    sectionColor: Color,
+    sectionIcon: ImageVector,
+    throwable: Throwable,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        GameSectionHeader(
+            sectionType = sectionType,
+            modifier = Modifier,
+        )
+
+        ErrorCard(
+            error = throwable.toErrorMessage(),
+            sectionColor = sectionColor,
+            sectionIcon = sectionIcon,
+            onRetry = onRetry,
+            modifier = Modifier.padding(horizontal = 12.dp),
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSections.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSections.kt
@@ -18,15 +18,19 @@ import com.lilin.gamelibrary.ui.component.toErrorMessage
 
 @Composable
 fun TrendingGamesSection(
+    isSuccessState: Boolean,
     games: List<Game>,
     onGameClick: (Game) -> Unit,
+    onReload: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,
     ) {
         GameSectionHeader(
+            isSuccessState = isSuccessState,
             sectionType = SectionType.TRENDING,
+            onReload = onReload,
             modifier = Modifier,
         )
 
@@ -40,21 +44,34 @@ fun TrendingGamesSection(
                     onClick = { onGameClick(game) },
                 )
             }
+
+            item {
+                SeeMoreCard(
+                    sectionType = SectionType.TRENDING,
+                    onClick = {
+                        // TODO: See More
+                    },
+                )
+            }
         }
     }
 }
 
 @Composable
 fun HighRatedGamesSection(
+    isSuccessState: Boolean,
     games: List<Game>,
     onGameClick: (Game) -> Unit,
+    onReload: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,
     ) {
         GameSectionHeader(
+            isSuccessState = isSuccessState,
             sectionType = SectionType.HIGH_RATED,
+            onReload = onReload,
             modifier = Modifier,
         )
 
@@ -68,21 +85,34 @@ fun HighRatedGamesSection(
                     onClick = { onGameClick(game) },
                 )
             }
+
+            item {
+                SeeMoreCard(
+                    sectionType = SectionType.HIGH_RATED,
+                    onClick = {
+                        // TODO: See More
+                    },
+                )
+            }
         }
     }
 }
 
 @Composable
 fun NewReleaseGamesSection(
+    isSuccessState: Boolean,
     games: List<Game>,
     onGameClick: (Game) -> Unit,
+    onReload: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,
     ) {
         GameSectionHeader(
+            isSuccessState = isSuccessState,
             sectionType = SectionType.NEW_RELEASE,
+            onReload = onReload,
             modifier = Modifier,
         )
 
@@ -94,6 +124,15 @@ fun NewReleaseGamesSection(
                 NewReleaseGameCard(
                     game = game,
                     onClick = { onGameClick(game) },
+                )
+            }
+
+            item {
+                SeeMoreCard(
+                    sectionType = SectionType.NEW_RELEASE,
+                    onClick = {
+                        // TODO: See More
+                    },
                 )
             }
         }
@@ -110,7 +149,9 @@ fun LoadingGamesSection(
         modifier = modifier,
     ) {
         GameSectionHeader(
+            isSuccessState = false,
             sectionType = sectionType,
+            onReload = { /** no-op **/ },
             modifier = Modifier,
         )
 
@@ -136,7 +177,9 @@ fun ErrorSection(
 ) {
     Column(modifier = modifier) {
         GameSectionHeader(
+            isSuccessState = false,
             sectionType = sectionType,
+            onReload = { /** no-op **/ },
             modifier = Modifier,
         )
 
@@ -181,8 +224,10 @@ private fun TrendingGamesSectionPreview() {
     )
 
     TrendingGamesSection(
+        isSuccessState = true,
         games = sampleGames,
         onGameClick = {},
+        onReload = {},
     )
 }
 
@@ -217,8 +262,10 @@ private fun HighMetacriticGamesSectionPreview() {
     )
 
     HighRatedGamesSection(
+        isSuccessState = true,
         games = sampleGames,
         onGameClick = {},
+        onReload = {},
     )
 }
 
@@ -253,7 +300,9 @@ private fun NewReleaseGamesSectionPreview() {
     )
 
     NewReleaseGamesSection(
+        isSuccessState = true,
         games = sampleGames,
         onGameClick = {},
+        onReload = {},
     )
 }

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSections.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSections.kt
@@ -101,6 +101,31 @@ fun NewReleaseGamesSection(
 }
 
 @Composable
+fun LoadingGamesSection(
+    sectionType: SectionType,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        GameSectionHeader(
+            sectionType = sectionType,
+            modifier = Modifier,
+        )
+
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp),
+        ) {
+            items(4) {
+                content()
+            }
+        }
+    }
+}
+
+@Composable
 fun ErrorSection(
     sectionType: SectionType,
     sectionColor: Color,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="discover_section_trending_sub_title">今話題のゲーム</string>
     <string name="discover_section_high_rated_sub_title">高評価タイトル</string>
     <string name="discover_section_new_release_sub_title">最新リリース</string>
+    <string name="discover_game_card_see_more">もっと見る</string>
     <string name="discover_trend_card_badge">TREND</string>
     <string name="discover_high_rated_card_badge">HIGH RATED</string>
     <string name="discover_new_release_card_badge">NEW</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,12 @@
     <string name="navigation_label_home">Home</string>
     <string name="navigation_label_search">Search</string>
     <string name="navigation_label_favorite">Favorite</string>
-    <string name="discover_screen_title">見つける</string>
+    <string name="discover_screen_title">Game Library</string>
+    <string name="discovery_loading_message">読み込み中...</string>
+    <string name="discovery_error_message">データの読み込みに失敗しました</string>
+    <string name="discovery_error_submessage">インターネット接続を確認して\nもう一度お試しください</string>
+    <string name="discovery_retry_button_text">再読み込み</string>
+    <string name="discovery_retry_section_button_text">もう一度試す</string>
     <string name="discovery_trending_section_title">トレンドゲーム</string>
     <string name="discovery_metacritic_section_title">メタスコア殿堂入り</string>
     <string name="discovery_new_release_section_title">新着ゲーム</string>

--- a/app/src/test/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSectionHeaderScreenShotTest.kt
+++ b/app/src/test/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSectionHeaderScreenShotTest.kt
@@ -21,7 +21,9 @@ class GameSectionHeaderScreenShotTest {
     fun gameSectionHeader_Trending() {
         composeTestRule.captureMultiDevice("GameSectionHeader_Trend") {
             GameSectionHeader(
+                isSuccessState = true,
                 sectionType = SectionType.TRENDING,
+                onReload = {},
             )
         }
     }
@@ -30,7 +32,9 @@ class GameSectionHeaderScreenShotTest {
     fun gameSectionHeader_HighRated() {
         composeTestRule.captureMultiDevice("GameSectionHeader_HighRate") {
             GameSectionHeader(
+                isSuccessState = true,
                 sectionType = SectionType.HIGH_RATED,
+                onReload = {},
             )
         }
     }
@@ -39,7 +43,42 @@ class GameSectionHeaderScreenShotTest {
     fun gameSectionHeader_NewRelease() {
         composeTestRule.captureMultiDevice("GameSectionHeader_NewRelease") {
             GameSectionHeader(
+                isSuccessState = true,
                 sectionType = SectionType.NEW_RELEASE,
+                onReload = {},
+            )
+        }
+    }
+
+    @Test
+    fun gameSectionHeader_Trending_isSuccessState_false() {
+        composeTestRule.captureMultiDevice("GameSectionHeader_Trend_false") {
+            GameSectionHeader(
+                isSuccessState = false,
+                sectionType = SectionType.TRENDING,
+                onReload = {},
+            )
+        }
+    }
+
+    @Test
+    fun gameSectionHeader_HighRated_isSuccessState_false() {
+        composeTestRule.captureMultiDevice("GameSectionHeader_HighRate_false") {
+            GameSectionHeader(
+                isSuccessState = false,
+                sectionType = SectionType.HIGH_RATED,
+                onReload = {},
+            )
+        }
+    }
+
+    @Test
+    fun gameSectionHeader_NewRelease_isSuccessState_false() {
+        composeTestRule.captureMultiDevice("GameSectionHeader_NewRelease_false") {
+            GameSectionHeader(
+                isSuccessState = false,
+                sectionType = SectionType.NEW_RELEASE,
+                onReload = {},
             )
         }
     }

--- a/app/src/test/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSectionsScreenShotTest.kt
+++ b/app/src/test/kotlin/com/lilin/gamelibrary/ui/component/discovery/GameSectionsScreenShotTest.kt
@@ -2,6 +2,10 @@ package com.lilin.gamelibrary.ui.component.discovery
 
 import android.content.Context
 import androidx.activity.ComponentActivity
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.NewReleases
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Whatshot
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -15,6 +19,9 @@ import coil3.asImage
 import coil3.test.FakeImageLoaderEngine
 import com.lilin.gamelibrary.R
 import com.lilin.gamelibrary.domain.model.Game
+import com.lilin.gamelibrary.ui.theme.HighRatedGradientStart
+import com.lilin.gamelibrary.ui.theme.NewReleaseGradientStart
+import com.lilin.gamelibrary.ui.theme.TrendingGradientStart
 import com.lilin.gamelibrary.util.captureMultiDevice
 import org.junit.Before
 import org.junit.Rule
@@ -54,8 +61,10 @@ class GameSectionsScreenShotTest {
     fun trendingGamesSection_ScreenShot() {
         composeTestRule.captureMultiDevice("TrendingGamesSection") {
             TrendingGamesSection(
+                isSuccessState = true,
                 games = GAMES,
                 onGameClick = {},
+                onReload = {},
             )
         }
     }
@@ -64,8 +73,10 @@ class GameSectionsScreenShotTest {
     fun highRatedGamesSection_ScreenShot() {
         composeTestRule.captureMultiDevice("HighRatedGamesSection") {
             HighRatedGamesSection(
+                isSuccessState = true,
                 games = GAMES,
                 onGameClick = {},
+                onReload = {},
             )
         }
     }
@@ -74,8 +85,82 @@ class GameSectionsScreenShotTest {
     fun newReleaseGamesSection_ScreenShot() {
         composeTestRule.captureMultiDevice("NewReleaseGamesSection") {
             NewReleaseGamesSection(
+                isSuccessState = true,
                 games = GAMES,
                 onGameClick = {},
+                onReload = {},
+            )
+        }
+    }
+
+    @Test
+    fun trendingGamesSection_ScreenShot_isSuccessState_false() {
+        composeTestRule.captureMultiDevice("TrendingGamesSection_false") {
+            TrendingGamesSection(
+                isSuccessState = false,
+                games = GAMES,
+                onGameClick = {},
+                onReload = {},
+            )
+        }
+    }
+
+    @Test
+    fun highRatedGamesSection_ScreenShot_isSuccessState_false() {
+        composeTestRule.captureMultiDevice("HighRatedGamesSection_false") {
+            HighRatedGamesSection(
+                isSuccessState = false,
+                games = GAMES,
+                onGameClick = {},
+                onReload = {},
+            )
+        }
+    }
+
+    @Test
+    fun newReleaseGamesSection_ScreenShot_isSuccessState_false() {
+        composeTestRule.captureMultiDevice("NewReleaseGamesSection_false") {
+            NewReleaseGamesSection(
+                isSuccessState = false,
+                games = GAMES,
+                onGameClick = {},
+                onReload = {},
+            )
+        }
+    }
+
+    fun errorSection_TrendingGames_ScreenShot() {
+        composeTestRule.captureMultiDevice("ErrorSection_TrendingGames") {
+            ErrorSection(
+                sectionType = SectionType.TRENDING,
+                sectionColor = TrendingGradientStart,
+                sectionIcon = Icons.Filled.Whatshot,
+                throwable = Throwable(),
+                onRetry = {},
+            )
+        }
+    }
+
+    fun errorSection_HighRatedGames_ScreenShot() {
+        composeTestRule.captureMultiDevice("ErrorSection_HighRatedGames") {
+            ErrorSection(
+                sectionType = SectionType.HIGH_RATED,
+                sectionColor = HighRatedGradientStart,
+                sectionIcon = Icons.Filled.Star,
+                throwable = Throwable(),
+                onRetry = {},
+            )
+        }
+    }
+
+    fun errorSection_NewReleaseGames_ScreenShot() {
+        composeTestRule.captureMultiDevice("ErrorSection_NewReleaseGames") {
+            ErrorSection(
+                sectionType = SectionType.NEW_RELEASE,
+                sectionColor = NewReleaseGradientStart,
+                sectionIcon = Icons.Filled.NewReleases,
+                throwable = Throwable(),
+                onRetry = {},
             )
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ okhttp3 = "4.12.0"
 retrofit-converter = "1.0.0"
 coil = "3.3.0"
 room = "2.8.4"
+shimmer = "1.3.3"
 # DI
 hilt = "2.57.2"
 hiltNavigation = "1.3.0"
@@ -63,6 +64,7 @@ retrofit2-kotlinx-serialization-converter = { group = "com.jakewharton.retrofit"
 okhttp3-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp3" }
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+compose-shimmer = { group = "com.valentinilk.shimmer", name = "compose-shimmer", version.ref = "shimmer" }
 
 # DI
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }


### PR DESCRIPTION
## 🎯 概要
`compose-shimmer`ライブラリを使用して、各GameCard（Trending/HighRated/NewRelease）のスケルトンローディングを実装します。

## 📋 背景
現在、Loading状態では何も表示されず、ユーザーにとって待機時間が不明確です。Shimmer効果を持つLoadingカードを表示することで、よりリッチなUXを提供します。

## 🎨 デザイン方針
- 実際のGameCardと同じサイズ・形状
- Shimmer効果でアニメーション
- プレースホルダーは各カードの構造に合わせる
