### PR TITLE
【Animation】画面遷移のアニメーションを追加

### DIFF
--- a/app/src/main/kotlin/com/lilin/gamelibrary/navigation/TopLevelDestination.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/navigation/TopLevelDestination.kt
@@ -10,12 +10,16 @@ import com.lilin.gamelibrary.R
 import com.lilin.gamelibrary.feature.discovery.DiscoveryScreen
 import com.lilin.gamelibrary.feature.favorite.FavoriteScreen
 import com.lilin.gamelibrary.feature.search.SearchScreen
+import kotlinx.serialization.Serializable
 
 data class TopLevelDestination<T : Any>(
     val route: T,
     val icon: ImageVector,
     @param:StringRes val label: Int,
 )
+
+@Serializable
+object BottomNavGraph
 
 val TOP_LEVEL_ROUTES = listOf(
     TopLevelDestination(

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/GameLibraryApp.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/GameLibraryApp.kt
@@ -1,5 +1,9 @@
 package com.lilin.gamelibrary.ui
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
@@ -7,21 +11,30 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import com.lilin.gamelibrary.feature.detail.GameDetailScreen
 import com.lilin.gamelibrary.feature.detail.navigateDetailScreen
 import com.lilin.gamelibrary.feature.discovery.DiscoveryScreen
 import com.lilin.gamelibrary.feature.discovery.navigateDiscoveryScreen
+import com.lilin.gamelibrary.feature.favorite.FavoriteScreen
 import com.lilin.gamelibrary.feature.favorite.navigateFavoriteScreen
+import com.lilin.gamelibrary.feature.search.SearchScreen
 import com.lilin.gamelibrary.feature.search.navigateSearchScreen
 import com.lilin.gamelibrary.feature.sectiondetail.SectionDetailScreen
 import com.lilin.gamelibrary.feature.sectiondetail.navigateSectionDetailScreen
+import com.lilin.gamelibrary.navigation.BottomNavGraph
 import com.lilin.gamelibrary.navigation.TOP_LEVEL_ROUTES
 import com.lilin.gamelibrary.ui.component.GameLibraryNavigationBar
+
+private const val DURATION_MILLIS = 500
 
 @Composable
 fun GameLibraryApp(
@@ -72,8 +85,69 @@ private fun AppNavHost(
 ) {
     NavHost(
         navController = navController,
-        startDestination = DiscoveryScreen,
+        startDestination = BottomNavGraph,
         modifier = modifier,
+        enterTransition = { fadeIn(tween(DURATION_MILLIS)) },
+        exitTransition = { fadeOut(tween(DURATION_MILLIS)) },
+        popEnterTransition = { fadeIn(tween(DURATION_MILLIS)) },
+        popExitTransition = { fadeOut(tween(DURATION_MILLIS)) },
+    ) {
+        bottomNavGraph(navController)
+
+        navigateDetailScreen(onBackClick = navController::popBackStack)
+
+        navigateSectionDetailScreen(
+            onBackClick = navController::popBackStack,
+            onNavigateToDetail = { gameId ->
+                navController.navigate(GameDetailScreen(gameId))
+            },
+        )
+    }
+}
+
+private fun NavGraphBuilder.bottomNavGraph(navController: NavHostController) {
+    navigation<BottomNavGraph>(
+        startDestination = DiscoveryScreen,
+        enterTransition = {
+            if (isDetailScreen(initialState, targetState)) {
+                fadeIn(tween(DURATION_MILLIS))
+            } else {
+                slideIntoContainer(
+                    towards = getSlideDirection(initialState, targetState),
+                    animationSpec = tween(DURATION_MILLIS),
+                )
+            }
+        },
+        exitTransition = {
+            if (isDetailScreen(initialState, targetState)) {
+                fadeOut(tween(DURATION_MILLIS))
+            } else {
+                slideOutOfContainer(
+                    towards = getSlideDirection(initialState, targetState),
+                    animationSpec = tween(DURATION_MILLIS),
+                )
+            }
+        },
+        popEnterTransition = {
+            if (isDetailScreen(initialState, targetState)) {
+                fadeIn(tween(DURATION_MILLIS))
+            } else {
+                slideIntoContainer(
+                    towards = getSlideDirection(initialState, targetState),
+                    animationSpec = tween(DURATION_MILLIS),
+                )
+            }
+        },
+        popExitTransition = {
+            if (isDetailScreen(initialState, targetState)) {
+                fadeOut(tween(DURATION_MILLIS))
+            } else {
+                slideOutOfContainer(
+                    towards = getSlideDirection(initialState, targetState),
+                    animationSpec = tween(DURATION_MILLIS),
+                )
+            }
+        },
     ) {
         navigateDiscoveryScreen(
             onNavigateToDetail = { gameId ->
@@ -83,15 +157,6 @@ private fun AppNavHost(
                 navController.navigate(SectionDetailScreen(sectionTypeName = sectionType.name))
             },
         )
-
-        navigateSectionDetailScreen(
-            onBackClick = navController::popBackStack,
-            onNavigateToDetail = { gameId ->
-                navController.navigate(GameDetailScreen(gameId))
-            },
-        )
-
-        navigateDetailScreen(onBackClick = navController::popBackStack)
 
         navigateSearchScreen(
             navigateToDetail = { gameId ->
@@ -104,5 +169,42 @@ private fun AppNavHost(
                 navController.navigate(GameDetailScreen(gameId))
             },
         )
+    }
+}
+
+private fun isDetailScreen(
+    initialState: NavBackStackEntry,
+    targetState: NavBackStackEntry,
+): Boolean {
+    // 詳細画面からの遷移
+    val isInitialMoveGameDetailScreen = initialState.destination.hasRoute<GameDetailScreen>()
+    val isInitialMoveSectionDetailScreen = initialState.destination.hasRoute<SectionDetailScreen>()
+    // 詳細画面への遷移
+    val isTargetMoveGameDetailScreen = targetState.destination.hasRoute<GameDetailScreen>()
+    val isTargetMoveSectionDetailScreen = targetState.destination.hasRoute<SectionDetailScreen>()
+
+    return (isInitialMoveGameDetailScreen || isInitialMoveSectionDetailScreen) || (isTargetMoveGameDetailScreen || isTargetMoveSectionDetailScreen)
+}
+
+private fun getSlideDirection(
+    from: NavBackStackEntry,
+    to: NavBackStackEntry,
+): AnimatedContentTransitionScope.SlideDirection {
+    val fromIndex = getScreenIndex(from)
+    val toIndex = getScreenIndex(to)
+
+    return if (toIndex > fromIndex) {
+        AnimatedContentTransitionScope.SlideDirection.Start
+    } else {
+        AnimatedContentTransitionScope.SlideDirection.End
+    }
+}
+
+private fun getScreenIndex(entry: NavBackStackEntry): Int {
+    return when {
+        entry.destination.hasRoute<DiscoveryScreen>() -> 0
+        entry.destination.hasRoute<SearchScreen>() -> 1
+        entry.destination.hasRoute<FavoriteScreen>() -> 2
+        else -> 0
     }
 }

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/sectiondetail/GameGridCard.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/sectiondetail/GameGridCard.kt
@@ -1,0 +1,691 @@
+@file:OptIn(ExperimentalSharedTransitionApi::class)
+
+package com.lilin.gamelibrary.ui.component.sectiondetail
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
+import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material.icons.rounded.Games
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.lilin.gamelibrary.R
+import com.lilin.gamelibrary.domain.model.Game
+import com.lilin.gamelibrary.feature.sectiondetail.DisplayMode
+import com.lilin.gamelibrary.ui.component.LabeledIcon
+import com.lilin.gamelibrary.ui.component.discovery.SectionType
+import com.lilin.gamelibrary.ui.theme.HighRatedGradientEnd
+import com.lilin.gamelibrary.ui.theme.HighRatedGradientStart
+import com.lilin.gamelibrary.ui.theme.NewReleaseGradientEnd
+import com.lilin.gamelibrary.ui.theme.NewReleaseGradientStart
+import com.lilin.gamelibrary.ui.theme.RatingBronze
+import com.lilin.gamelibrary.ui.theme.RatingEmpty
+import com.lilin.gamelibrary.ui.theme.RatingGold
+import com.lilin.gamelibrary.ui.theme.RatingSilver
+import com.lilin.gamelibrary.ui.theme.TrendingGradientEnd
+import com.lilin.gamelibrary.ui.theme.TrendingGradientStart
+import java.util.Locale
+
+private const val METACRITIC_GOLD_THRESHOLD = 90
+private const val METACRITIC_SILVER_THRESHOLD = 70
+private const val METACRITIC_BRONZE_THRESHOLD = 50
+
+@Composable
+fun TrendingGameCard(
+    game: Game,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    with(sharedTransitionScope) {
+        Card(
+            onClick = onClick,
+            modifier = modifier
+                .size(200.dp, 220.dp)
+                .shadow(
+                    elevation = 16.dp,
+                    shape = RoundedCornerShape(16.dp),
+                    ambientColor = TrendingGradientStart.copy(alpha = 0.3f),
+                    spotColor = TrendingGradientStart.copy(alpha = 0.3f),
+                )
+                .sharedElement(
+                    rememberSharedContentState(key = "game-${game.id}"),
+                    animatedVisibilityScope = animatedVisibilityScope,
+                ),
+            shape = RoundedCornerShape(16.dp),
+            elevation = CardDefaults.cardElevation(0.dp),
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                GameImageWithOverlay(game.imageUrl)
+
+                TrendingBadge(
+                    badgeText = stringResource(R.string.discover_trend_card_badge),
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(12.dp),
+                )
+
+                TrendingGameInfoOverlay(
+                    name = game.name,
+                    rating = game.displayRating,
+                    releaseYear = game.releaseYear?.toString(),
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(horizontal = 12.dp, vertical = 16.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun HighRatedGameCard(
+    game: Game,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    with(sharedTransitionScope) {
+        Card(
+            onClick = onClick,
+            modifier = modifier
+                .size(200.dp, 220.dp)
+                .shadow(
+                    elevation = 16.dp,
+                    shape = RoundedCornerShape(16.dp),
+                    ambientColor = HighRatedGradientStart.copy(alpha = 0.3f),
+                    spotColor = HighRatedGradientStart.copy(alpha = 0.3f),
+                )
+                .sharedElement(
+                    rememberSharedContentState(key = "game-${game.id}"),
+                    animatedVisibilityScope = animatedVisibilityScope,
+                ),
+            shape = RoundedCornerShape(16.dp),
+            elevation = CardDefaults.cardElevation(0.dp),
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                GameImageWithOverlay(
+                    imageUrl = game.imageUrl,
+                    modifier = Modifier.fillMaxSize(),
+                )
+
+                HighRatedBadge(
+                    badgeText = stringResource(R.string.discover_high_rated_card_badge),
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(12.dp),
+                )
+
+                MetacriticBadge(
+                    metaScore = game.metacriticScore,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(12.dp),
+                )
+
+                HighRatedGameInfoOverlay(
+                    name = game.name,
+                    rating = game.displayRating,
+                    ratingsCount = game.ratingsCount,
+                    platforms = game.platforms,
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(horizontal = 12.dp, vertical = 16.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun NewReleaseGameCard(
+    game: Game,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    with(sharedTransitionScope) {
+        Card(
+            onClick = onClick,
+            modifier = modifier
+                .width(200.dp)
+                .height(220.dp)
+                .shadow(
+                    elevation = 16.dp,
+                    shape = RoundedCornerShape(16.dp),
+                    ambientColor = NewReleaseGradientStart.copy(alpha = 0.3f),
+                    spotColor = NewReleaseGradientStart.copy(alpha = 0.3f),
+                )
+                .sharedElement(
+                    rememberSharedContentState(key = "game-${game.id}"),
+                    animatedVisibilityScope = animatedVisibilityScope,
+                ),
+            shape = RoundedCornerShape(16.dp),
+            elevation = CardDefaults.cardElevation(0.dp),
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                GameImageWithOverlay(game.imageUrl)
+
+                NewReleaseBadge(
+                    badgeText = stringResource(R.string.discover_new_release_card_badge),
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(12.dp),
+                )
+
+                NewReleaseGameInfoOverlay(
+                    name = game.name,
+                    releaseDate = game.releaseDate,
+                    platforms = game.platforms,
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(horizontal = 12.dp, vertical = 16.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GameImageWithOverlay(
+    imageUrl: String?,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        if (imageUrl.isNullOrBlank()) {
+            Image(
+                painter = painterResource(R.drawable.ic_broken_image),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+            )
+        } else {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            Color.Transparent,
+                            Color.Black.copy(alpha = 0.7f),
+                        ),
+                        startY = 0f,
+                        endY = Float.POSITIVE_INFINITY,
+                    ),
+                ),
+        )
+    }
+}
+
+@Composable
+private fun TrendingBadge(
+    badgeText: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .width(60.dp)
+            .height(28.dp)
+            .background(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(
+                        TrendingGradientStart,
+                        TrendingGradientEnd,
+                    ),
+                ),
+                shape = RoundedCornerShape(6.dp),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = badgeText,
+            color = Color.White,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun HighRatedBadge(
+    badgeText: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .width(72.dp)
+            .height(28.dp)
+            .background(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(
+                        HighRatedGradientStart,
+                        HighRatedGradientEnd,
+                    ),
+                ),
+                shape = RoundedCornerShape(6.dp),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = badgeText,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+    }
+}
+
+@Composable
+private fun NewReleaseBadge(
+    badgeText: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .width(52.dp)
+            .height(28.dp)
+            .background(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(
+                        NewReleaseGradientStart,
+                        NewReleaseGradientEnd,
+                    ),
+                ),
+                shape = RoundedCornerShape(6.dp),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = badgeText,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+    }
+}
+
+@Composable
+private fun MetacriticBadge(
+    metaScore: Int,
+    modifier: Modifier = Modifier,
+) {
+    val badgeColor = getMetacriticColor(metaScore)
+
+    Box(
+        modifier = modifier
+            .size(56.dp, 56.dp)
+            .background(
+                color = badgeColor,
+                shape = RoundedCornerShape(12.dp),
+            )
+            .shadow(
+                elevation = 8.dp,
+                ambientColor = badgeColor.copy(alpha = 0.3f),
+                spotColor = badgeColor.copy(alpha = 0.3f),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = metaScore.toString(),
+            color = Color.White,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.ExtraBold,
+        )
+    }
+}
+
+@Composable
+private fun TrendingGameInfoOverlay(
+    name: String,
+    rating: String,
+    releaseYear: String?,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = name,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            LabeledIcon(
+                content = rating,
+                imageVector = Icons.Rounded.Star,
+                contentDescription = "Rating",
+                tint = Color.White.copy(alpha = 0.9f),
+            )
+            releaseYear?.let { year ->
+                LabeledIcon(
+                    content = year,
+                    imageVector = Icons.Rounded.CalendarMonth,
+                    contentDescription = "Release Year",
+                    tint = Color.White.copy(alpha = 0.9f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HighRatedGameInfoOverlay(
+    name: String,
+    rating: String,
+    ratingsCount: Int?,
+    platforms: List<String>?,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = name,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            LabeledIcon(
+                content = buildString {
+                    append(rating)
+                    ratingsCount?.let { count ->
+                        append(" (${formatCount(count)})")
+                    }
+                },
+                imageVector = Icons.Rounded.Star,
+                contentDescription = "Rating",
+                tint = Color.White.copy(alpha = 0.9f),
+            )
+            platforms?.let { platforms ->
+                LabeledIcon(
+                    content = platforms.joinToString("・"),
+                    imageVector = Icons.Rounded.Games,
+                    contentDescription = "Platform",
+                    tint = Color.White.copy(alpha = 0.9f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NewReleaseGameInfoOverlay(
+    name: String,
+    releaseDate: String?,
+    platforms: List<String>?,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = name,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            releaseDate?.let { date ->
+                LabeledIcon(
+                    content = date,
+                    imageVector = Icons.Rounded.CalendarMonth,
+                    contentDescription = "Release Date",
+                    tint = Color.White.copy(alpha = 0.9f),
+                )
+            }
+
+            platforms?.let { platforms ->
+                LabeledIcon(
+                    content = platforms.joinToString("・"),
+                    imageVector = Icons.Rounded.Games,
+                    contentDescription = "Platform",
+                    tint = Color.White.copy(alpha = 0.9f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SeeMoreCard(
+    sectionType: SectionType,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.size(200.dp, 220.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp),
+                    tint = sectionType.gradientStart,
+                )
+
+                Text(
+                    text = stringResource(R.string.discover_game_card_see_more),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                Text(
+                    text = stringResource(sectionType.titleId),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Metacriticスコアに応じた色を取得。
+ */
+fun getMetacriticColor(score: Int): Color {
+    return when {
+        score >= METACRITIC_GOLD_THRESHOLD -> RatingGold
+        score >= METACRITIC_SILVER_THRESHOLD -> RatingSilver
+        score >= METACRITIC_BRONZE_THRESHOLD -> RatingBronze
+        else -> RatingEmpty
+    }
+}
+
+/**
+ * 数値をフォーマット（例：1234 → 1.2k）
+ */
+fun formatCount(count: Int): String {
+    return when {
+        count >= 1000 -> {
+            String.format(Locale.ROOT, "%.1fk", count / 1000.0)
+        }
+
+        else -> count.toString()
+    }
+}
+
+@Preview
+@Composable
+private fun TrendingGameCardPreview() {
+    val game = Game(
+        id = 1,
+        name = "League of Legends",
+        imageUrl = null,
+        releaseDate = "2018-12-31",
+        rating = 4.5,
+        ratingsCount = 1523,
+        metacritic = 80,
+        isTba = false,
+        addedCount = 5000,
+        platforms = listOf("Switch", "PS5", "PC"),
+    )
+    SharedTransitionLayout {
+        AnimatedContent(
+            targetState = DisplayMode.GRID_COLUMN,
+        ) {
+            TrendingGameCard(
+                game = game,
+                sharedTransitionScope = this@SharedTransitionLayout,
+                animatedVisibilityScope = this@AnimatedContent,
+                onClick = {},
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun HighRatedGameCardPreview() {
+    val game = Game(
+        id = 1,
+        name = "League of Legends",
+        imageUrl = null,
+        releaseDate = "2018-12-31",
+        rating = 4.5,
+        ratingsCount = 1523,
+        metacritic = 90,
+        isTba = false,
+        addedCount = 5000,
+        platforms = listOf("Switch", "PS5", "PC"),
+    )
+    SharedTransitionLayout {
+        AnimatedContent(
+            targetState = DisplayMode.GRID_COLUMN,
+        ) {
+            HighRatedGameCard(
+                game = game,
+                sharedTransitionScope = this@SharedTransitionLayout,
+                animatedVisibilityScope = this@AnimatedContent,
+                onClick = {},
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun NewReleaseGameCardPreview() {
+    val game = Game(
+        id = 1,
+        name = "League of Legends",
+        imageUrl = null,
+        releaseDate = "2028-12-31",
+        rating = 4.5,
+        ratingsCount = 1523,
+        metacritic = 80,
+        isTba = false,
+        addedCount = 20000,
+        platforms = listOf("Switch", "PS5", "PC"),
+    )
+    SharedTransitionLayout {
+        AnimatedContent(
+            targetState = DisplayMode.GRID_COLUMN,
+        ) {
+            NewReleaseGameCard(
+                game = game,
+                sharedTransitionScope = this@SharedTransitionLayout,
+                animatedVisibilityScope = this@AnimatedContent,
+                onClick = {},
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SeeMoreCardPreview() {
+    SeeMoreCard(
+        sectionType = SectionType.TRENDING,
+        onClick = {},
+    )
+}

--- a/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/sectiondetail/GameListCard.kt
+++ b/app/src/main/kotlin/com/lilin/gamelibrary/ui/component/sectiondetail/GameListCard.kt
@@ -1,5 +1,8 @@
 package com.lilin.gamelibrary.ui.component.sectiondetail
 
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -34,94 +37,107 @@ import coil3.compose.AsyncImage
 import com.lilin.gamelibrary.domain.model.Game
 import com.lilin.gamelibrary.ui.component.LabeledIcon
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun GameListCard(
     game: Game,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
     onGameClick: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(100.dp)
-            .clickable { onGameClick(game.id) },
-        shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant,
-        ),
-        elevation = CardDefaults.cardElevation(
-            defaultElevation = 2.dp,
-        ),
-    ) {
-        Row(
-            modifier = Modifier
+    with(sharedTransitionScope) {
+        Card(
+            modifier = modifier
                 .fillMaxWidth()
-                .padding(12.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                .height(100.dp)
+                .clickable { onGameClick(game.id) }
+                .sharedElement(
+                    sharedContentState = rememberSharedContentState(key = "game-${game.id}"),
+                    animatedVisibilityScope = animatedVisibilityScope,
+                ),
+            shape = RoundedCornerShape(12.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+            elevation = CardDefaults.cardElevation(
+                defaultElevation = 2.dp,
+            ),
         ) {
-            AsyncImage(
-                model = game.imageUrl,
-                contentDescription = game.name,
+            Row(
                 modifier = Modifier
-                    .size(76.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(
-                        Brush.verticalGradient(
-                            colors = listOf(
-                                Color(0xFF1A1A1A),
-                                Color(0xFF2A2A2A),
+                    .fillMaxWidth()
+                    .padding(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                AsyncImage(
+                    model = game.imageUrl,
+                    contentDescription = game.name,
+                    modifier = Modifier
+                        .size(76.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(
+                            Brush.verticalGradient(
+                                colors = listOf(
+                                    Color(0xFF1A1A1A),
+                                    Color(0xFF2A2A2A),
+                                ),
                             ),
                         ),
-                    ),
-                contentScale = ContentScale.Crop,
-            )
-
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(
-                    text = game.name,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
+                    contentScale = ContentScale.Crop,
                 )
 
-                Spacer(modifier = Modifier.height(4.dp))
-
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.SpaceBetween,
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.Star,
-                        contentDescription = null,
-                        tint = Color(0xFFFFD700),
-                        modifier = Modifier.size(16.dp),
-                    )
                     Text(
-                        text = String.format(Locale.current.platformLocale, "%.1f", game.rating),
-                        style = MaterialTheme.typography.bodySmall,
+                        text = game.name,
+                        style = MaterialTheme.typography.titleSmall,
                         fontWeight = FontWeight.Bold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
                     )
-                }
 
-                game.releaseDate?.let { released ->
-                    Text(
-                        text = released,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+                    Spacer(modifier = Modifier.height(4.dp))
 
-                game.platforms?.let { platforms ->
-                    LabeledIcon(
-                        content = platforms.joinToString("・"),
-                        imageVector = Icons.Rounded.Games,
-                        contentDescription = "Platform",
-                        tint = Color.White.copy(alpha = 0.9f),
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = null,
+                            tint = Color(0xFFFFD700),
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Text(
+                            text = String.format(
+                                Locale.current.platformLocale,
+                                "%.1f",
+                                game.rating,
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
+
+                    game.releaseDate?.let { released ->
+                        Text(
+                            text = released,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                    game.platforms?.let { platforms ->
+                        LabeledIcon(
+                            content = platforms.joinToString("・"),
+                            imageVector = Icons.Rounded.Games,
+                            contentDescription = "Platform",
+                            tint = Color.White.copy(alpha = 0.9f),
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 📋 概要

SectionDetail画面の表示モード切り替えアニメーションと、アプリ全体の画面遷移アニメーションを実装しました。

## 🎯 実装内容

### 1. SectionDetail画面の表示モード切り替えアニメーション

- **AnimatedContentの導入**
  - グリッド表示⇔リスト表示の切り替え時にスムーズなアニメーション
  - トランジション時間: 500ms

- **スクロール状態の保持**
  - `rememberLazyGridState()`と`rememberLazyListState()`によるスクロール位置管理
  - 表示モード切り替え時にスクロール位置を同期
  - `LaunchedEffect`を使用した自動スクロール位置調整

- **SharedTransitionLayoutの導入**
  - GameCard間のShared Element Transition対応
  - グリッド表示・リスト表示の各カードにSharedTransitionScopeを追加

### 2. 画面遷移アニメーション

- **BottomNavGraphの導入**
  - Top-Level Navigation（Discovery/Search/Favorite）を`navigation`でグルーピング
  - Detail画面（GameDetail/SectionDetail）と階層を分離

- **遷移パターンの実装**
  
  **Top-Level Navigation間（Discovery/Search/Favorite）:**
  - スライドアニメーション（500ms）
  - 画面の位置関係に基づく方向制御
    - Discovery(0) ⇔ Search(1) ⇔ Favorite(2)
    - 右へ移動: `SlideDirection.Start`
    - 左へ移動: `SlideDirection.End`

  **Detail画面への遷移（GameDetail/SectionDetail）:**
  - フェードイン/フェードアウト（500ms）
  - GameCard押下時の自然な遷移

- **ヘルパー関数の実装**
```kotlin
  involvesDetailScreen()  // 遷移にDetail画面が含まれるか判定
  getSlideDirection()     // Top-Level Navigation間のスライド方向取得
  NavBackStackEntry.isDetailScreen()  // Detail画面かどうか判定（拡張関数）
  getScreenIndex()        // 画面のインデックス取得
```

### 3. GameCardコンポーネントの再構成

- **新規ファイル: GameGridCard.kt**
  - `TrendingGameCard`
  - `HighRatedGameCard`
  - `NewReleaseGameCard`
  - SectionDetail画面専用のGameCard（SharedTransition対応）
  - Discovery画面のカードと分離して管理

- **GameListCard.ktの更新**
  - SharedTransitionScope対応
  - `sharedElement()`修飾子の追加

## 🎨 UX改善

- **表示モード切り替え時**
  - スクロール位置が維持され、ユーザーの閲覧位置が保たれる
  - スムーズなアニメーションで視覚的なフィードバック

- **画面遷移時**
  - BottomBar Navigation: 画面位置に応じた直感的なスライド
  - Detail画面: フェードで画面

- **アニメーション時間**
  - 全遷移: 500ms（`DURATION_MILLIS`定数で統一）